### PR TITLE
IPv6 Support (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ By having to initialize kubernetes client-set, the tool intrinsically performs A
 |                                                  | K8s DNS name lookup for specific service check          |
 |                                                  | Path MTU discovery between Src & Dst Pod (icmp)         |
 |                                                  | Path MTU discovery between Src Pod & External IP (icmp) |
+|                                                  | All K8s service endpoints IP connectivity check (icmp)  |
 
 ## How to build from source
 To build tool from source, run `make` as follows:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 ![master](https://github.com/sarun87/k8snetlook/workflows/Build%20&%20Test/badge.svg?branch=master)
 
 # k8snetlook
-
 Kubernetes Network Problem Detector
 
 ## Introduction
-A simple tool to help debug connetivity issues within a Pod or from a specific host in a live kubernetes cluster easily with a single command.
+A simple tool to help debug connetivity issues within a Pod or from a specific host in a live kubernetes cluster easily with a single command. Works with both IPv4 as well as IPv6 K8s stacks.
 
 ## Background
 When connectivity between two applications within a Kubernetes cluster does not work as expected, it requires specific troubleshooting steps in real time to find the issue. Often times, this involves using network tools such as `ping`, `tcpdump`, `traceroute`, `nslookup` and others to vaildate the plumbing; both within the source Pod as well as on the host that the pod is running.
@@ -97,8 +96,7 @@ kubectl delete -f examples/run-k8s.yaml
 * To rerun the test, delete k8snetlook and re-apply.
 
 ## Checks currently supported by the tool
-
-By having to initialize kubernetes client-set, the tool intrinsically performs API connectivity check via K8s-apiserver's VIP/External Loadbalancer in case of highly available k8s-apiserver clusters
+By having to initialize kubernetes client-set, the tool intrinsically performs API connectivity check via K8s-apiserver's VIP/External Loadbalancer in case of highly available k8s-apiserver clusters. The tool supports pure IPv6 K8s stack as well as IPv4.
 
 | Host Checks                                      | Pod Checks                                              |
 | ------------------------------------------------ | ------------------------------------------------------- |

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/miekg/dns v1.1.31
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -158,6 +160,7 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200930145003-4acb6c075d10 h1:YfxMZzv3PjGonQYNUaeU2+DhAdqOxerQ30JFB6WgAXo=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/k8snetlook/checkers.go
+++ b/k8snetlook/checkers.go
@@ -43,7 +43,7 @@ func RunDstConnectivityCheck(dstIP string) (bool, error) {
 func RunKubeAPIServiceIPConnectivityCheck() (bool, error) {
 	// TODO: Handle secure/non-secure api-servers
 	// HTTP 401 return code is a successful check
-	url := fmt.Sprintf("https://%s:%d", Cfg.KubeAPIService.IP, Cfg.KubeAPIService.Port)
+	url := fmt.Sprintf("https://%s", net.JoinHostPort(Cfg.KubeAPIService.IP, string(Cfg.KubeAPIService.Port)))
 	var body []byte
 	responseCode, err := netutils.SendRecvHTTPMessage(url, "", &body)
 	if err != nil {
@@ -69,7 +69,7 @@ func RunKubeAPIEndpointIPConnectivityCheck() (bool, error) {
 	}
 	passedCount := 0
 	for _, ep := range endpoints {
-		url := fmt.Sprintf("https://%s:%d", ep.IP, ep.Port)
+		url := fmt.Sprintf("https://%s", net.JoinHostPort(ep.IP, string(ep.Port)))
 		log.Debug("  checking endpoint: %s ........", url)
 		var body []byte
 		responseCode, err := netutils.SendRecvHTTPMessage(url, "", &body)
@@ -94,7 +94,7 @@ func RunKubeAPIEndpointIPConnectivityCheck() (bool, error) {
 
 // RunAPIServerHealthCheck checks api server health using livez endpoint
 func RunAPIServerHealthCheck() (bool, error) {
-	url := fmt.Sprintf("https://%s:%d/livez?verbose", Cfg.KubeAPIService.IP, Cfg.KubeAPIService.Port)
+	url := fmt.Sprintf("https://%s/livez?verbose", net.JoinHostPort(Cfg.KubeAPIService.IP, string(Cfg.KubeAPIService.Port)))
 	svcAccountToken, err := getSvcAccountToken()
 	if err != nil {
 		log.Debug("  (Failed) ", err)
@@ -117,7 +117,7 @@ func RunAPIServerHealthCheck() (bool, error) {
 
 // RunK8sDNSLookupCheck checks DNS lookup functionality for a given K8s service
 func RunK8sDNSLookupCheck(dnsServerIP, dstSvcName, dstSvcNamespace, dstSvcExpectedIP string) (bool, error) {
-	dnsServerURL := fmt.Sprintf("%s:53", dnsServerIP)
+	dnsServerURL := net.JoinHostPort(dnsServerIP, "53")
 	// TODO: Fetch domain information from cluster
 	svcfqdn := fmt.Sprintf("%s.%s.svc.cluster.local.", dstSvcName, dstSvcNamespace)
 	ips, err := netutils.RunDNSLookupUsingCustomResolver(dnsServerURL, svcfqdn)

--- a/k8snetlook/init.go
+++ b/k8snetlook/init.go
@@ -99,6 +99,7 @@ func initK8sInfo() error {
 	}
 	if Cfg.DstSvc.Name != "" && Cfg.DstSvc.Namespace != "" {
 		Cfg.DstSvc.ClusterIP, _ = getServiceClusterIP(Cfg.DstSvc.Namespace, Cfg.DstSvc.Name)
+		Cfg.DstSvc.SvcEndpoints = getEndpointsFromService(Cfg.DstSvc.Namespace, Cfg.DstSvc.Name)
 	}
 	return nil
 }

--- a/k8snetlook/init.go
+++ b/k8snetlook/init.go
@@ -25,9 +25,10 @@ type Pod struct {
 
 // Service struct specifies properties required for decribing a K8s service
 type Service struct {
-	Name        string
-	Namespace   string
-	SvcEndpoint Endpoint
+	Name         string
+	Namespace    string
+	ClusterIP    Endpoint
+	SvcEndpoints []Endpoint
 }
 
 // Endpoint struct specifies properties that an Endpoint represents
@@ -97,7 +98,7 @@ func initK8sInfo() error {
 		Cfg.DstPod.IP = getPodIPFromName(Cfg.DstPod.Namespace, Cfg.DstPod.Name)
 	}
 	if Cfg.DstSvc.Name != "" && Cfg.DstSvc.Namespace != "" {
-		Cfg.DstSvc.SvcEndpoint, _ = getServiceClusterIP(Cfg.DstSvc.Namespace, Cfg.DstSvc.Name)
+		Cfg.DstSvc.ClusterIP, _ = getServiceClusterIP(Cfg.DstSvc.Namespace, Cfg.DstSvc.Name)
 	}
 	return nil
 }

--- a/k8snetlook/pod.go
+++ b/k8snetlook/pod.go
@@ -80,12 +80,17 @@ func RunPodChecks() {
 			Name: "pMTU check for ExternalIP", Success: pass, ErrorMsg: err})
 	}
 
-	if Cfg.DstSvc.SvcEndpoint.IP != "" {
+	if Cfg.DstSvc.ClusterIP.IP != "" {
 		log.Debug("----> [From SrcPod] Running DstSvc DNS lookup check..")
 		pass, err = RunK8sDNSLookupCheck(Cfg.KubeDNSService.IP, Cfg.DstSvc.Name, Cfg.DstSvc.Namespace,
-			Cfg.DstSvc.SvcEndpoint.IP)
+			Cfg.DstSvc.ClusterIP.IP)
 		allChecks.PodChecks = append(allChecks.PodChecks, Check{
 			Name: "DNS lookup for DstSvc", Success: pass, ErrorMsg: err})
+
+		log.Debug("----> [From SrcPod] Running DstSvc Endpoints connectivity check..")
+		pass, err = RunDstSvcEndpointsConnectivityCheck(Cfg.DstSvc.SvcEndpoints)
+		allChecks.PodChecks = append(allChecks.PodChecks, Check{
+			Name: "DstSvc Endpoints connectivity check", Success: pass, ErrorMsg: err})
 	}
 
 	// Change network ns back to host

--- a/netutils/dnsutil_test.go
+++ b/netutils/dnsutil_test.go
@@ -1,0 +1,17 @@
+package netutils
+
+import (
+	"testing"
+)
+
+func TestDNSLookupGoogle(t *testing.T) {
+	res, err := RunDNSLookupUsingCustomResolver("8.8.8.8:53", "www.google.com")
+	if err != nil {
+		t.Errorf("Unable to resolve Google using Google DNS! Error:%v", err)
+	}
+	t.Logf("Resolved IPs:%v\n", res)
+	// Should have an IPv4 and an IPv6 address for Google
+	if len(res) != 2 {
+		t.Errorf("DNS resolution for www.google.com into ipv4 and ipv6 addresses failed with Google DNS")
+	}
+}

--- a/netutils/httputil_test.go
+++ b/netutils/httputil_test.go
@@ -4,8 +4,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 )
+
+func skipTest(t *testing.T) {
+	if os.Getenv("TESTIPV6") == "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+}
 
 func TestSendRecvHTTPMessageV4(t *testing.T) {
 	var body []byte
@@ -22,6 +29,8 @@ func TestSendRecvHTTPMessageV4(t *testing.T) {
 }
 
 func TestSendRecvHTTPMessageV6(t *testing.T) {
+	// Skip when run through make test
+	skipTest(t)
 	var body []byte
 	// TODO: Use localtest server for unit testing
 	// Use www.google.com IPV6 address

--- a/netutils/httputil_test.go
+++ b/netutils/httputil_test.go
@@ -1,0 +1,36 @@
+package netutils
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestSendRecvHTTPMessageV4(t *testing.T) {
+	var body []byte
+	// Use Google IPv4 Address
+	url := "http://172.217.9.4:80"
+	responseCode, err := SendRecvHTTPMessage(url, "", &body)
+	if err != nil {
+		t.Errorf("Unable to fetch response Error: %v", err)
+	}
+	if responseCode != http.StatusOK {
+		t.Errorf("Response code not 200")
+	}
+	t.Logf("%s", body)
+}
+
+func TestSendRecvHTTPMessageV6(t *testing.T) {
+	var body []byte
+	// TODO: Use localtest server for unit testing
+	// Use www.google.com IPV6 address
+	url := fmt.Sprintf("http://%s", net.JoinHostPort("2607:f8b0:4005:804::2004", "80"))
+	responseCode, err := SendRecvHTTPMessage(url, "", &body)
+	if err != nil {
+		t.Errorf("Unable to fetch response Error: %v", err)
+	}
+	if responseCode != http.StatusNotFound {
+		t.Errorf("Expected 404. Got:%v", responseCode)
+	}
+}

--- a/netutils/icmputil.go
+++ b/netutils/icmputil.go
@@ -3,7 +3,10 @@ package netutils
 import (
 	"fmt"
 	"net"
+	"os"
 	"time"
+
+	"golang.org/x/net/ipv6"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -17,9 +20,84 @@ const (
 	defaultPayloadSize = 64
 )
 
+// SendRecvICMPMessage checks if icmp ping is successful.
+// Looks at 2 icmp packets for required response
+// returncode: 0 - no error. Echo reply received successfully
+//			   1 - Fragmentation required
+//             2 - got icmp but unknwon type
+func SendRecvICMPMessage(dstIP string, payloadSize int, dontFragment bool) (int, error) {
+	// Note: Does not handle IPv4 literal in IPv6. TODO later
+	ip := net.ParseIP(dstIP)
+	if ip.To4() != nil {
+		// IPv4
+		return sendRecvICMPMessageV4(dstIP, payloadSize, dontFragment)
+	}
+	// IPv6
+	return sendRecvICMPMessageV6(dstIP, payloadSize)
+
+}
+
+// sendRecvICMPMessageV4 checks if icmp ping is successful.
+// Looks at 2 icmp packets for required response
+// returncode: 0 - no error. Echo reply received successfully
+//			   1 - Fragmentation required
+//             2 - got icmp but unknwon type
+func sendRecvICMPMessageV4(dstIP string, payloadSize int, dontFragment bool) (int, error) {
+	// Listen for ICMP reply on all IPs
+	c, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return -1, fmt.Errorf("Unable to open icmp socket for ping test: %v", err)
+	}
+	defer c.Close()
+
+	// Send ICMP message
+	if err := sendICMPMessageV4(dstIP, payloadSize, dontFragment); err != nil {
+		return -1, err
+	}
+
+	rb := make([]byte, payloadSize)
+	c.SetReadDeadline(time.Now().Add(time.Second * icmpTimeout))
+
+	// Read reply. Try twice. Discard echo request if read back on 127.0.0.1 (Needed for unit tests)
+	for tries := 0; tries < 2; tries++ {
+		n, _, err := c.ReadFrom(rb)
+		if err != nil {
+			if err.(net.Error).Timeout() {
+				return -1, fmt.Errorf("ICMP timeout")
+			}
+			return -1, fmt.Errorf("Unable to read reply from icmp socket: %v", err)
+		}
+		// Check if read message is an ICMP message
+		rm, err := icmp.ParseMessage(ipv4.ICMPTypeEchoReply.Protocol(), rb[:n])
+		if err != nil {
+			return -1, fmt.Errorf("Unable to parse ICMP message:%v", err)
+		}
+		// Check to see if ICMP message type is ECHO reply
+		switch rm.Type {
+		case ipv4.ICMPTypeEchoReply:
+			// Reflection received successfully. Return success
+			// log.Debug("    got reflection from %v with payload size:%d\n", peer, payloadSize)
+			// To check if echo reply is specific to this app, check message
+			// b, _ := rm.Body.Marshal(1)  // 1 : ICMPv4 type protocol number
+			// icmpMessage == string(b[2:2+len(icmpMessageBody)])  // First two bytes: length of body
+			return 0, nil
+		case ipv4.ICMPTypeDestinationUnreachable:
+			if rm.Code == layers.ICMPv4CodeFragmentationNeeded {
+				// log.Debug("   Fragmentation required, and DF flag set\n")
+				return 1, nil
+			}
+		default:
+			// log.Debug("    got %+v; want echo reply\n", rm)
+			// Try multiple messages
+		}
+	}
+	// Got ICMP type but not an echo reply
+	return 2, nil
+}
+
 // sendICMPMessage sends a single ICMP packet over the wire
 // Picked from https://github.com/ipsecdiagtool/ipsecdiagtool project & modified as necessary
-func sendICMPMessage(dstIP string, payloadSize int, dontfragment bool) error {
+func sendICMPMessageV4(dstIP string, payloadSize int, dontfragment bool) error {
 	// If an additional payload size isn't specified, use default
 	if payloadSize < defaultPayloadSize {
 		payloadSize = defaultPayloadSize
@@ -77,22 +155,44 @@ func sendICMPMessage(dstIP string, payloadSize int, dontfragment bool) error {
 	return rawConn.WriteTo(ipHeader, payloadBuf.Bytes(), nil)
 }
 
-// SendRecvICMPMessage checks if icmp ping is successful.
+// sendRecvICMPMessageV6 checks if icmp ping is successful.
 // Looks at 2 icmp packets for required response
 // returncode: 0 - no error. Echo reply received successfully
 //			   1 - Fragmentation required
 //             2 - got icmp but unknwon type
-func SendRecvICMPMessage(dstIP string, payloadSize int, dontFragment bool) (int, error) {
-	// Listen on all IPs
-	c, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+func sendRecvICMPMessageV6(dstIP string, payloadSize int) (int, error) {
+	// Don't fragment is always set for IPv6. IPv6 packets cannot be fragmented
+	// Listen for ICMP reply on all IPs
+	c, err := icmp.ListenPacket("ip6:ipv6-icmp", "::")
 	if err != nil {
 		return -1, fmt.Errorf("Unable to open icmp socket for ping test: %v", err)
 	}
 	defer c.Close()
 
-	if err := sendICMPMessage(dstIP, payloadSize, dontFragment); err != nil {
-		return -1, err
+	// If an additional payload size isn't specified, use default
+	if payloadSize < defaultPayloadSize {
+		payloadSize = defaultPayloadSize
 	}
+	payloadbytes := []byte(icmpMessageBody)
+	if payloadSize > len(icmpMessageBody) {
+		padding := make([]byte, payloadSize-len(icmpMessageBody))
+		payloadbytes = append(payloadbytes, padding...)
+	}
+	wm := icmp.Message{
+		Type: ipv6.ICMPTypeEchoRequest, Code: 0,
+		Body: &icmp.Echo{
+			ID: os.Getpid() & 0xffff, Seq: 1,
+			Data: payloadbytes,
+		},
+	}
+	wb, err := wm.Marshal(nil)
+	if err != nil {
+		return -1, fmt.Errorf("Unable to convert icmp echo message to byte string: %v", err)
+	}
+	if _, err := c.WriteTo(wb, &net.IPAddr{IP: net.ParseIP(dstIP)}); err != nil {
+		return -1, fmt.Errorf("Unable to send icmp echo request to %s:%v", dstIP, err)
+	}
+
 	rb := make([]byte, payloadSize)
 	c.SetReadDeadline(time.Now().Add(time.Second * icmpTimeout))
 
@@ -106,24 +206,22 @@ func SendRecvICMPMessage(dstIP string, payloadSize int, dontFragment bool) (int,
 			return -1, fmt.Errorf("Unable to read reply from icmp socket: %v", err)
 		}
 		// Check if read message is an ICMP message
-		rm, err := icmp.ParseMessage(ipv4.ICMPTypeEchoReply.Protocol(), rb[:n])
+		rm, err := icmp.ParseMessage(ipv6.ICMPTypeEchoReply.Protocol(), rb[:n])
 		if err != nil {
 			return -1, fmt.Errorf("Unable to parse ICMP message:%v", err)
 		}
 		// Check to see if ICMP message type is ECHO reply
 		switch rm.Type {
-		case ipv4.ICMPTypeEchoReply:
+		case ipv6.ICMPTypeEchoReply:
 			// Reflection received successfully. Return success
 			// log.Debug("    got reflection from %v with payload size:%d\n", peer, payloadSize)
 			// To check if echo reply is specific to this app, check message
 			// b, _ := rm.Body.Marshal(1)  // 1 : ICMPv4 type protocol number
 			// icmpMessage == string(b[2:2+len(icmpMessageBody)])  // First two bytes: length of body
 			return 0, nil
-		case ipv4.ICMPTypeDestinationUnreachable:
-			if rm.Code == layers.ICMPv4CodeFragmentationNeeded {
-				// log.Debug("   Fragmentation required, and DF flag set\n")
-				return 1, nil
-			}
+		case ipv6.ICMPTypePacketTooBig:
+			// log.Debug("   Fragmentation required, and DF flag set\n")
+			return 1, nil
 		default:
 			// log.Debug("    got %+v; want echo reply\n", rm)
 			// Try multiple messages

--- a/netutils/icmputil.go
+++ b/netutils/icmputil.go
@@ -99,7 +99,7 @@ func sendRecvICMPMessageV4(dstIP string, payloadSize int, dontFragment bool) (in
 				return 1, nil
 			}
 		default:
-			log.Debug("    got %+v; want echo reply\n", rm)
+			//log.Debug("    got %+v; want echo reply\n", rm)
 		}
 	}
 	// Got ICMP type but not an echo reply

--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -5,12 +5,27 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	log "github.com/sarun87/k8snetlook/logutil"
 	"github.com/vishvananda/netlink"
 )
 
 // GetHostGatewayIP returns the IP of the default gw as listed in the route list
 func GetHostGatewayIP() (string, error) {
-	routes, err := netlink.RouteList(nil, unix.AF_INET)
+	gwIP, err := getHostGatewayIPUsingFamily(unix.AF_INET)
+	if err != nil {
+		log.Debug("Error: %v", err)
+		// If we are here, there was a problem returning list v4 routes. Try v6 routes
+		gwIP, err = getHostGatewayIPUsingFamily(unix.AF_INET6)
+		if err != nil {
+			// v6 gw route not found either. Return nil
+			return "", err
+		}
+	}
+	return gwIP, nil
+}
+
+func getHostGatewayIPUsingFamily(family int) (string, error) {
+	routes, err := netlink.RouteList(nil, family)
 	if err != nil {
 		return "", err
 	}

--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -31,7 +31,7 @@ func getHostGatewayIPUsingFamily(family int) (string, error) {
 	}
 	for _, r := range routes {
 		// Check if the route is marked as a gw route
-		if r.Gw != nil {
+		if r.Gw != nil && r.Dst == nil {
 			return r.Gw.String(), nil
 		}
 	}


### PR DESCRIPTION
Addresses Issue #15 

Notes: pmtud for ipv6 is still broken. Need to figure out how to disable fragmentation of ICMPv6 packets

changes:
* Add connectivity check to all endpoints of a given service (`DstSvc`)
* Change code throughout the tool to support pure-IPv6 K8s stack. This includes:
** `dnsutils.go` sends two DNS requests, one for `A` record and one for `AAAA` record
** `httputils.go` takes IPv6 addresses for `GET` requests
** `icmputils.go` supports `ICMPv6` ping-pong messages for connectivity checks
* icmp check now looks for 10 ICMP replies before giving up.
* Fixes an issue with reusing `ICMPv6` Echo message `ID` field for messages across host and pod network ns. 